### PR TITLE
feat: Habilitar treesit-fold por defecto para scripts de Python

### DIFF
--- a/init.el
+++ b/init.el
@@ -352,6 +352,12 @@
             (setq comint-output-filter-functions
                   (remove 'comint-truncate-buffer comint-output-filter-functions))))
 
+;;; treesit-fold configuration
+(use-package treesit-fold
+  :ensure t
+  :config
+  (global-treesit-fold-mode 1))
+
 (custom-set-variables
  ;; custom-set-variables was added by Custom.
  ;; If you edit it by hand, you could mess it up, so be careful.


### PR DESCRIPTION
He configurado Emacs para que use `treesit-fold` para el plegado de código en scripts de Python por defecto. Para lograr esto, realicé los siguientes cambios en `init.el`:
- Agregué el paquete `treesit-fold` desde MELPA.
- Habilité `global-treesit-fold-mode`, que activa automáticamente el plegado para los modos mayores que usan `treesit`.

Dado que utilizas Emacs 30, `treesit-fold` es el paquete apropiado ya que se integra con el `treesit.el` incorporado. Esto te proporcionará plegado de código estructural por defecto en tus búferes de Python.