### PR TITLE
Configure Python mode keybindings and hooks

### DIFF
--- a/init.el
+++ b/init.el
@@ -287,6 +287,13 @@
   :ensure t
   :after yasnippet)
 
+;;; Python configuration
+(use-package python-mode
+  :ensure t
+  :hook (python-mode . python-ts-mode)
+  :bind (:map python-mode-map
+              ("C-c C-f" . treesit-fold-toggle)))
+
 (use-package org-bullets
   :ensure t
   :after org


### PR DESCRIPTION
- Add a keybinding for `treesit-fold-toggle` to `C-c C-f` in Python mode.
- Add a hook to enable `python-ts-mode` automatically with `python-mode`.