### PR TITLE
feat: make kill-ring history persistent

### DIFF
--- a/init.el
+++ b/init.el
@@ -58,6 +58,15 @@
   ;; Save on Emacs exit
   (add-hook 'kill-emacs-hook #'recentf-save-list))
 
+;;; Savehist - Persistent history for kill-ring
+(use-package savehist
+  :ensure nil ; Included with Emacs
+  :init
+  (setq savehist-file (concat user-emacs-directory ".savehist")
+        savehist-additional-variables '(kill-ring))
+  :config
+  (savehist-mode 1))
+
 ;; Line numbers
 (global-display-line-numbers-mode 0)
 


### PR DESCRIPTION
This change adds the necessary configuration to `init.el` to make the `kill-ring` history persistent across Emacs sessions.

It uses `savehist-mode`, which is a built-in Emacs feature, to save the `kill-ring` variable to a file when Emacs exits and restore it on startup.

The configuration is added using a `use-package` declaration for consistency with the existing configuration file.