### PR TITLE
feat(company): Accept completion with tab only

### DIFF
--- a/init.el
+++ b/init.el
@@ -335,7 +335,11 @@
   (setq company-tooltip-align-annotations t)
   :bind
   (:map company-active-map
-        ([escape] . company-abort)))
+        ([escape] . company-abort)
+        ("<return>" . nil)
+        ("RET" . nil)
+        ("<tab>" . company-complete-selection)
+        ("TAB" . company-complete-selection)))
 
 ;; ;;; Company backend for org-roam tags
 ;; (defun my/org-roam-get-all-tags ()


### PR DESCRIPTION
Configure company-mode to accept completion suggestions only with the tab key, and not with the enter key.

This is achieved by unbinding `<return>` and `RET` in `company-active-map` and binding `<tab>` and `TAB` to `company-complete-selection`.